### PR TITLE
Do not change the type of offer.TakerPays and offer.TakerGets

### DIFF
--- a/src/js/services/books.js
+++ b/src/js/services/books.js
@@ -43,37 +43,40 @@ module.factory('rpBooks', ['rpNetwork', '$q', '$rootScope', '$filter', 'rpId',
         return false;
       }
 
-      if (d.TakerGets.value) {
-        d.TakerGets.value = d.taker_gets_funded;
+      d.TakerGetsFunded = d.TakerGets;
+      d.TakerPaysFunded = d.TakerPays;
+
+      if (d.TakerGetsFunded.value) {
+        d.TakerGetsFunded.value = d.taker_gets_funded;
       } else {
-        d.TakerGets = parseInt(Number(d.taker_gets_funded), 10);
+        d.TakerGetsFunded = parseInt(Number(d.taker_gets_funded), 10);
       }
 
-      if (d.TakerPays.value) {
-        d.TakerPays.value = d.taker_pays_funded;
+      if (d.TakerPaysFunded.value) {
+        d.TakerPaysFunded.value = d.taker_pays_funded;
       } else {
-        d.TakerPays = parseInt(Number(d.taker_pays_funded), 10);
+        d.TakerPaysFunded = parseInt(Number(d.taker_pays_funded), 10);
       }
 
-      d.TakerGets = deprecated.Amount.from_json(d.TakerGets);
-      d.TakerPays = deprecated.Amount.from_json(d.TakerPays);
+      d.TakerGetsFunded = deprecated.Amount.from_json(d.TakerGetsFunded);
+      d.TakerPaysFunded = deprecated.Amount.from_json(d.TakerPaysFunded);
 
       // You never know
-      if (!d.TakerGets.is_valid() || !d.TakerPays.is_valid()) {
+      if (!d.TakerGetsFunded.is_valid() || !d.TakerPaysFunded.is_valid()) {
         return false;
       }
 
       if (action === 'asks') {
-        d.price = deprecated.Amount.from_quality(d.BookDirectory, d.TakerPays.currency(),
-          d.TakerPays.issuer(), {
-            base_currency: d.TakerGets.currency(),
+        d.price = deprecated.Amount.from_quality(d.BookDirectory, d.TakerPaysFunded.currency(),
+          d.TakerPaysFunded.issuer(), {
+            base_currency: d.TakerGetsFunded.currency(),
             reference_date: new Date()
           });
       } else {
-        d.price = deprecated.Amount.from_quality(d.BookDirectory, d.TakerGets.currency(),
-          d.TakerGets.issuer(), {
+        d.price = deprecated.Amount.from_quality(d.BookDirectory, d.TakerGetsFunded.currency(),
+          d.TakerGetsFunded.issuer(), {
             inverse: true,
-            base_currency: d.TakerPays.currency(),
+            base_currency: d.TakerPaysFunded.currency(),
             reference_date: new Date()
           });
       }
@@ -90,8 +93,8 @@ module.factory('rpBooks', ['rpNetwork', '$q', '$rootScope', '$filter', 'rpId',
 
       if (lastprice === price && !d.my) {
         if (combine) {
-          newData[current].TakerPays = deprecated.Amount.from_json(newData[current].TakerPays).add(d.TakerPays);
-          newData[current].TakerGets = deprecated.Amount.from_json(newData[current].TakerGets).add(d.TakerGets);
+          newData[current].TakerPaysFunded = deprecated.Amount.from_json(newData[current].TakerPaysFunded).add(d.TakerPaysFunded);
+          newData[current].TakerGetsFunded = deprecated.Amount.from_json(newData[current].TakerGetsFunded).add(d.TakerGetsFunded);
         }
         d = false;
       } else {
@@ -113,7 +116,7 @@ module.factory('rpBooks', ['rpNetwork', '$q', '$rootScope', '$filter', 'rpId',
       return d;
     })));
 
-    var key = action === 'asks' ? 'TakerGets' : 'TakerPays';
+    var key = action === 'asks' ? 'TakerGetsFunded' : 'TakerPaysFunded';
     var sum;
     _.forEach(newData, function (order) {
       if (sum) {

--- a/src/js/tabs/trade.js
+++ b/src/js/tabs/trade.js
@@ -1033,7 +1033,7 @@ TradeTab.prototype.angular = function(module)
               order.showSum = rpamountFilter(order.sum,OrderbookFilterOpts);
               order.showPrice = rpamountFilter(order.price,OrderbookFilterOpts);
 
-              var showValue = type === 'bids' ? 'TakerPays' : 'TakerGets';
+              var showValue = type === 'bids' ? 'TakerPaysFunded' : 'TakerGetsFunded';
               order['show' + showValue] = rpamountFilter(order[showValue],OrderbookFilterOpts);
             });
           }

--- a/src/templates/tabs/trade.jade
+++ b/src/templates/tabs/trade.jade
@@ -118,17 +118,18 @@ section.col-xs-12.content(ng-controller="TradeCtrl")
             span(l10n) Bid
             span &#32&#61;&#32;
             span.value
-              | {{book.bids[0].TakerGets | rpamountratio:book.bids[0].TakerPays | rpamount:{rel_precision: 5, rel_min_precision: 5} }}
+              | {{book.bids[0].TakerGetsFunded | rpamountratio:book.bids[0].TakerPaysFunded | rpamount:{rel_precision: 5, rel_min_precision: 5} }}
           li.col-xs-6.col-sm-3
             span(l10n) Ask
             span &#32&#61;&#32;
             span.value
-              | {{book.asks[0].TakerPays | rpamountratio:book.asks[0].TakerGets | rpamount:{rel_precision: 5, rel_min_precision: 5} }}
+              | {{book.asks[0].TakerPaysFunded | rpamountratio:book.asks[0].TakerGetsFunded | rpamount:{rel_precision: 5, rel_min_precision: 5} }}
           li.col-xs-6.col-sm-3
             span(l10n) Spread
             span &#32&#61;&#32;
             span.value
-              | {{book.asks[0].TakerPays | rpamountratio:book.asks[0].TakerGets | rpamountsubtract:(book.bids[0].TakerGets | rpamountratio:book.bids[0].TakerPays) | rpamount:{rel_precision: 5, rel_min_precision: 5} }}
+              | {{book.asks[0].TakerPaysFunded |
+              rpamountratio:book.asks[0].TakerGetsFunded | rpamountsubtract:(book.bids[0].TakerGetsFunded | rpamountratio:book.bids[0].TakerPaysFunded) | rpamount:{rel_precision: 5, rel_min_precision: 5} }}
           li.col-xs-6.col-sm-3
             span(l10n) Last price
             span &#32&#61;&#32;
@@ -458,24 +459,24 @@ section.col-xs-12.content(ng-controller="TradeCtrl")
               .title(l10n) Bids
               .row.head(ng-show="book.bids.length")
                 .col-xs-4.sum(l10n) Sum
-                  .currency {{book.bids[0].TakerPays | rpcurrency}}
+                  .currency {{book.bids[0].TakerPaysFunded | rpcurrency}}
                   .issuer(
-                    ng-show="(book.bids[0].TakerPays | rpcurrency) !== 'XRP'"
-                    rp-pretty-issuer="book.bids[0].TakerPays | rpissuer"
+                    ng-show="(book.bids[0].TakerPaysFunded | rpcurrency) !== 'XRP'"
+                    rp-pretty-issuer="book.bids[0].TakerPaysFunded | rpissuer"
                     rp-pretty-issuer-contacts="userBlob.data.contacts"
                     rp-pretty-issuer-or-short)
                 .col-xs-4.size(l10n) Size
-                  .currency {{book.bids[0].TakerPays | rpcurrency}}
+                  .currency {{book.bids[0].TakerPaysFunded | rpcurrency}}
                   .issuer(
-                    ng-show="(book.bids[0].TakerPays | rpcurrency) !== 'XRP'"
-                    rp-pretty-issuer="book.bids[0].TakerPays | rpissuer"
+                    ng-show="(book.bids[0].TakerPaysFunded | rpcurrency) !== 'XRP'"
+                    rp-pretty-issuer="book.bids[0].TakerPaysFunded | rpissuer"
                     rp-pretty-issuer-contacts="userBlob.data.contacts"
                     rp-pretty-issuer-or-short)
                 .col-xs-4.price(l10n) Bid Price
-                  .currency {{book.bids[0].TakerGets | rpcurrency}}
+                  .currency {{book.bids[0].TakerGetsFunded | rpcurrency}}
                   .issuer(
-                    ng-show="(book.bids[0].TakerGets | rpcurrency) !== 'XRP'"
-                    rp-pretty-issuer="book.bids[0].TakerGets | rpissuer"
+                    ng-show="(book.bids[0].TakerGetsFunded | rpcurrency) !== 'XRP'"
+                    rp-pretty-issuer="book.bids[0].TakerGetsFunded | rpissuer"
                     rp-pretty-issuer-contacts="userBlob.data.contacts"
                     rp-pretty-issuer-or-short)
               .row(ng-repeat='order in book.bids', ng-class="{my: order.my, cancelling: cancelling}", title="{{order.Account}}")
@@ -483,7 +484,7 @@ section.col-xs-12.content(ng-controller="TradeCtrl")
                   a(href=""
                     ng-click="fill_widget('sell',order,true)")
                     span(rp-bind-color-amount="order.showSum")
-                .col-xs-4.rpamount.size(rp-bind-color-amount="order.showTakerPays")
+                .col-xs-4.rpamount.size(rp-bind-color-amount="order.showTakerPaysFunded")
                 .col-xs-4.rpamount.price
                   a(href="", ng-click="fill_widget('sell',order)")
                     span(rp-bind-color-amount="order.showPrice")
@@ -492,31 +493,31 @@ section.col-xs-12.content(ng-controller="TradeCtrl")
               .title(l10n) Asks
               .row.head(ng-show="book.asks.length")
                 .col-xs-4.price(l10n) Ask Price
-                  .currency {{book.asks[0].TakerPays | rpcurrency}}
+                  .currency {{book.asks[0].TakerPaysFunded | rpcurrency}}
                   .issuer(
-                    ng-show="(book.asks[0].TakerPays | rpcurrency) !== 'XRP'"
-                    rp-pretty-issuer="book.asks[0].TakerPays | rpissuer"
+                    ng-show="(book.asks[0].TakerPaysFunded | rpcurrency) !== 'XRP'"
+                    rp-pretty-issuer="book.asks[0].TakerPaysFunded | rpissuer"
                     rp-pretty-issuer-contacts="userBlob.data.contacts"
                     rp-pretty-issuer-or-short)
                 .col-xs-4.size(l10n) Size
-                  .currency {{book.asks[0].TakerGets | rpcurrency}}
+                  .currency {{book.asks[0].TakerGetsFunded | rpcurrency}}
                   .issuer(
-                    ng-show="(book.asks[0].TakerGets | rpcurrency) !== 'XRP'"
-                    rp-pretty-issuer="book.asks[0].TakerGets | rpissuer"
+                    ng-show="(book.asks[0].TakerGetsFunded | rpcurrency) !== 'XRP'"
+                    rp-pretty-issuer="book.asks[0].TakerGetsFunded | rpissuer"
                     rp-pretty-issuer-contacts="userBlob.data.contacts"
                     rp-pretty-issuer-or-short)
                 .col-xs-4.sum(l10n) Sum
-                  .currency {{book.asks[0].TakerGets | rpcurrency}}
+                  .currency {{book.asks[0].TakerGetsFunded | rpcurrency}}
                   .issuer(
-                    ng-show="(book.asks[0].TakerGets | rpcurrency) !== 'XRP'"
-                    rp-pretty-issuer="book.asks[0].TakerGets | rpissuer"
+                    ng-show="(book.asks[0].TakerGetsFunded | rpcurrency) !== 'XRP'"
+                    rp-pretty-issuer="book.asks[0].TakerGetsFunded | rpissuer"
                     rp-pretty-issuer-contacts="userBlob.data.contacts"
                     rp-pretty-issuer-or-short)
               .row(ng-repeat='order in book.asks', ng-class="{my: order.my, cancelling: cancelling}", title="{{order.Account}}")
                 .col-xs-4.rpamount.price
                   a(href="", ng-click="fill_widget('buy',order)")
                     span(rp-bind-color-amount="order.showPrice")
-                .col-xs-4.rpamount.size(rp-bind-color-amount="order.showTakerGets")
+                .col-xs-4.rpamount.size(rp-bind-color-amount="order.showTakerGetsFunded")
                 .col-xs-4.rpamount.sum
                   a(href=""
                     ng-click="fill_widget('buy',order,true)")


### PR DESCRIPTION
Instead, add new properties: TakerPaysFunded and TakerGetsFunded

The offer objects are shared between the app and the Orderbook
(ripple-lib-orderbook) object. The latter expects these two fields to be
either a string ("XRP") or a plain object ("IOU").
Changing the type will cause exceptions.

The code was introduced in:
https://github.com/ripple/ripple-client-desktop/commit/8c1e2e4cbf376d16f7a9920163258ca4c3477377